### PR TITLE
Feature/dql2 26 dataset comments   display comment deleter

### DIFF
--- a/ckanext/data_qld_theme/templates/package/comment_list.html
+++ b/ckanext/data_qld_theme/templates/package/comment_list.html
@@ -90,12 +90,21 @@
                         {% endif %}
                     {% endif %}
                     <div class="comment-header-text">
-                        {% if 'user_state' in comment and comment.user_state == 'deleted' %}
-                            <em>{{ comment.user_login_name }}</em>
+                        {% if comment.state == 'active' %}
+                            {% set comment_on = 'commented on ' + h.render_datetime(comment.creation_date, "%d %b %Y, %-I:%M%p") %}
+                            {% if 'user_state' in comment and comment.user_state == 'deleted' %}
+                                <em>{{ comment.user_login_name }}</em> {{ comment_on }}
+                            {% else %}
+                                {% link_for _(comment.user_login_name), controller='user', action='read', id=comment.user_id %} {{ comment_on }}
+                            {% endif %}
                         {% else %}
-                            {% link_for _(comment.user_login_name), controller='user', action='read', id=comment.user_id %}
+                            {% set comment_deleted = 'Comment deleted by' %}
+                            {% if 'deleted_user_state' in comment and comment.deleted_user_state == 'deleted' %}
+                                {{ comment_deleted }} <em>{{ comment.deleted_user_login_name }}</em>
+                            {% else %}
+                                {{ comment_deleted }} {% link_for _(comment.deleted_user_login_name), controller='user', action='read', id=comment.user_id %}
+                            {% endif %}
                         {% endif %}
-                        commented on {{ h.render_datetime(comment.creation_date, "%d %b %Y, %-I:%M%p") }}
                         {% if comment.modified_date %}
                         &mdash; <small>({{ _('Modified') }} {{ h.render_datetime(comment.modified_date, "%d %b %Y, %-I:%M%p") }})</small>
                         {% endif %}

--- a/ckanext/data_qld_theme/templates/package/comment_list.html
+++ b/ckanext/data_qld_theme/templates/package/comment_list.html
@@ -90,20 +90,11 @@
                         {% endif %}
                     {% endif %}
                     <div class="comment-header-text">
-                        {% if comment.state == 'active' %}
-                            {% set comment_on = 'commented on ' + h.render_datetime(comment.creation_date, "%d %b %Y, %-I:%M%p") %}
-                            {% if 'user_state' in comment and comment.user_state == 'deleted' %}
-                                <em>{{ comment.user_login_name }}</em> {{ comment_on }}
-                            {% else %}
-                                {% link_for _(comment.user_login_name), controller='user', action='read', id=comment.user_id %} {{ comment_on }}
-                            {% endif %}
+                        {% set commented_on = 'commented on ' + h.render_datetime(comment.creation_date, "%d %b %Y, %-I:%M%p") %}
+                        {% if 'user_state' in comment and comment.user_state == 'deleted' %}
+                            <em>{{ comment.user_login_name }}</em> {{ commented_on }}
                         {% else %}
-                            {% set comment_deleted = 'Comment deleted by' %}
-                            {% if 'deleted_user_state' in comment and comment.deleted_user_state == 'deleted' %}
-                                {{ comment_deleted }} <em>{{ comment.deleted_user_login_name }}</em>
-                            {% else %}
-                                {{ comment_deleted }} {% link_for _(comment.deleted_user_login_name), controller='user', action='read', id=comment.user_id %}
-                            {% endif %}
+                            {% link_for _(comment.user_login_name), controller='user', action='read', id=comment.user_id %} {{ commented_on }}
                         {% endif %}
                         {% if comment.modified_date %}
                         &mdash; <small>({{ _('Modified') }} {{ h.render_datetime(comment.modified_date, "%d %b %Y, %-I:%M%p") }})</small>
@@ -118,7 +109,7 @@
                         <h3>{{ comment.subject }}</h3>
                     {% endif %}
                 {% else %}
-                    <p><strong>{{ _('This comment was deleted.') }}</strong></p>
+                    {% snippet "snippets/comment_deleted.html", comment=comment %}
                 {% endif %}
                 {% if comment.state != 'deleted' %}
                     <div class="content">

--- a/ckanext/data_qld_theme/templates/scheming/package/read.html
+++ b/ckanext/data_qld_theme/templates/scheming/package/read.html
@@ -6,17 +6,3 @@
     <li class="active"><a href="{{ h.url_for(controller='package', action='read', id=pkg.name) }}">{{ pkg.title }}</a></li>
 {% endblock %}
 
-{% block package_notes %}
-
-    {% resource "odi_certificates/odi_certificate.js" %}
-    {% resource "odi_certificates/odi_certificate.css" %}
-
-    <div id="odi_certificates"
-      data-module="odi_certificates"
-      data-module-certificate_api_urls="{{ h.odi_certificates_certificate_api_urls()}}"">
-        {% snippet "package/snippets/odi_certificate.html" %}
-    </div>
-
-    {{ super() }}
-
-{% endblock %}


### PR DESCRIPTION
- Removed ODI certificate output from dataset detail template (`scheming/package/read.html`)
- Abstracted deleted message to snippet in ckanext-ytp-comments extension
- Added support for legacy deleted comments with no `comment.deleted_by_user_id` value
