### PR TITLE
[DQL-211] Theme check for reporting plugin enabled

### DIFF
--- a/ckanext/data_qld_theme/plugin.py
+++ b/ckanext/data_qld_theme/plugin.py
@@ -36,6 +36,10 @@ def get_comment_notification_recipients_enabled():
     return config.get('ckan.comments.follow_mute_enabled', False)
 
 
+def is_reporting_enabled():
+    return 'data_qld_reporting' in config.get('ckan.plugins', '')
+
+
 def is_request_for_resource():
     """
     Searching for a url path for /dataset/ and /resource/
@@ -147,4 +151,5 @@ class DataQldThemePlugin(plugins.SingletonPlugin):
             'comment_notification_recipients_enabled': get_comment_notification_recipients_enabled,
             'populate_revision': populate_revision,
             'unreplied_comments_x_days': unreplied_comments_x_days,
+            'is_reporting_enabled': is_reporting_enabled
         }

--- a/ckanext/data_qld_theme/templates/user/dashboard.html
+++ b/ckanext/data_qld_theme/templates/user/dashboard.html
@@ -10,7 +10,7 @@
     {{ h.build_nav_icon('dashboard.datasets', _('My Datasets')) }}
     {{ h.build_nav_icon('dashboard.organizations', _('My Organizations')) }}
     {{ h.build_nav_icon('dashboard.groups', _('My Groups')) }}
-    {% if h.check_access('has_user_permission_for_some_org', {'permission': 'create_dataset'}) %}
+    {% if h.is_reporting_enabled() and h.check_access('has_user_permission_for_some_org', {'permission': 'create_dataset'}) %}
         {{ h.build_nav_icon('dashboard.reports', _('My Reports')) }}         
     {% endif %}
   </ul>


### PR DESCRIPTION
- Added helper function to check if `data_qld_reporting` plugin is enabled just in case `data-qld-theme` extension is deployed without adding `data_qld_reporting` to `ckan.plugins` in the `ini` file